### PR TITLE
Wire up can_use_tool option

### DIFF
--- a/examples/04_permission_callbacks.rs
+++ b/examples/04_permission_callbacks.rs
@@ -143,11 +143,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // Configure options with permission callback
-    // Note: Use `tools` to restrict available tools (not `allowed_tools`)
+    // Use Default permission mode so the CLI asks the SDK for permission on each tool use.
+    // Don't pre-allow any tools - let the callback decide.
     let options = ClaudeAgentOptions {
-        tools: Some(["Write", "Read", "Bash"].into()),
         model: Some("sonnet".to_string()), // Use Sonnet for lower cost
-        permission_mode: Some(claude_agent_sdk_rs::PermissionMode::AcceptEdits),
         can_use_tool: Some(permission_callback),
         max_turns: Some(10),
         ..Default::default()

--- a/src/internal/query_full.rs
+++ b/src/internal/query_full.rs
@@ -12,9 +12,7 @@ use tokio::sync::oneshot;
 use crate::errors::{ClaudeError, Result};
 use crate::types::hooks::{HookCallback, HookContext, HookInput, HookMatcher};
 use crate::types::mcp::McpSdkServerConfig;
-use crate::types::permissions::{
-    CanUseToolCallback, PermissionResult, ToolPermissionContext,
-};
+use crate::types::permissions::{CanUseToolCallback, PermissionResult, ToolPermissionContext};
 
 use super::transport::Transport;
 
@@ -303,15 +301,10 @@ impl QueryFull {
                 let tool_name = request_data
                     .get("tool_name")
                     .and_then(|v| v.as_str())
-                    .ok_or_else(|| {
-                        ClaudeError::ControlProtocol("Missing tool_name".to_string())
-                    })?
+                    .ok_or_else(|| ClaudeError::ControlProtocol("Missing tool_name".to_string()))?
                     .to_string();
 
-                let original_input = request_data
-                    .get("input")
-                    .cloned()
-                    .unwrap_or(json!({}));
+                let original_input = request_data.get("input").cloned().unwrap_or(json!({}));
 
                 // Parse permission suggestions if present
                 let suggestions = request_data
@@ -335,8 +328,8 @@ impl QueryFull {
                             "updatedInput": allow.updated_input.unwrap_or(original_input)
                         });
                         if let Some(updated_permissions) = allow.updated_permissions {
-                            response["updatedPermissions"] = serde_json::to_value(updated_permissions)
-                                .unwrap_or(json!([]));
+                            response["updatedPermissions"] =
+                                serde_json::to_value(updated_permissions).unwrap_or(json!([]));
                         }
                         response
                     }
@@ -585,10 +578,10 @@ mod tests {
     use super::*;
     use crate::types::permissions::{PermissionResultAllow, PermissionResultDeny};
     use async_trait::async_trait;
-    use futures::future::BoxFuture;
     use futures::FutureExt;
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use futures::future::BoxFuture;
     use std::sync::Mutex;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     /// Simple mock transport for testing - matches Python's MockTransport pattern
     struct MockTransport {
@@ -864,6 +857,9 @@ mod tests {
 
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(err.to_string().contains("can_use_tool callback is not provided"));
+        assert!(
+            err.to_string()
+                .contains("can_use_tool callback is not provided")
+        );
     }
 }

--- a/src/types/permissions.rs
+++ b/src/types/permissions.rs
@@ -12,7 +12,7 @@ pub type CanUseToolCallback = Arc<
 >;
 
 /// Context provided to permission callbacks
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ToolPermissionContext {
     /// Abort signal (future feature)
     pub signal: Option<()>,


### PR DESCRIPTION
While `ClaudeAgentOptions` currently includes `can_use_tool`, its behavior is not actually implemented. This change hooks up the option so that the `can_use_tool` callback actually gets executed when there's a permissions request.

I tried to follow the python SDK's implementation as closely as possible, including the test cases.