### PR TITLE
fix: handle rate_limit_event and unknown message types from CLI

### DIFF
--- a/src/types/messages.rs
+++ b/src/types/messages.rs
@@ -48,6 +48,12 @@ pub enum Message {
     /// Control cancel request (ignore this - it's internal control protocol)
     #[serde(rename = "control_cancel_request")]
     ControlCancelRequest(serde_json::Value),
+    /// Rate limit event from the API
+    #[serde(rename = "rate_limit_event")]
+    RateLimitEvent(serde_json::Value),
+    /// Unknown message type (forward-compatibility catch-all)
+    #[serde(other)]
+    Unknown,
 }
 
 /// User message

--- a/tests/real_fixtures_test.rs
+++ b/tests/real_fixtures_test.rs
@@ -549,11 +549,18 @@ fn test_malformed_json_error() {
 
 #[test]
 fn test_unknown_type_handling() {
-    // The Message enum should handle unknown types via serde
+    // The Message enum should gracefully handle unknown types via serde(other)
     let unknown = r#"{"type": "unknown_type", "data": {}}"#;
     let result = serde_json::from_str::<Message>(unknown);
-    // Should error on unknown type
-    assert!(result.is_err());
+    // Should deserialize as Message::Unknown instead of erroring
+    assert!(result.is_ok());
+    assert!(matches!(result.unwrap(), Message::Unknown));
+
+    // rate_limit_event should deserialize as RateLimitEvent
+    let rate_limit = r#"{"type": "rate_limit_event", "retry_after": 5}"#;
+    let result = serde_json::from_str::<Message>(rate_limit);
+    assert!(result.is_ok());
+    assert!(matches!(result.unwrap(), Message::RateLimitEvent(_)));
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Add `RateLimitEvent` variant to the `Message` enum to handle `rate_limit_event` messages emitted by the Claude CLI
- Add `#[serde(other)]` catch-all `Unknown` variant for forward-compatibility with any future unknown message types
- Update tests to verify both new variants deserialize correctly

## Problem

The Claude CLI can emit `rate_limit_event` messages during interactions. Since the `Message` enum didn't have a variant for this type, deserialization failed with:

```
unknown variant `rate_limit_event`, expected one of `assistant`, `system`, `result`, `stream_event`, `user`, `control_cancel_request`
```

## Test plan

- [x] `rate_limit_event` JSON deserializes as `Message::RateLimitEvent(_)`
- [x] Unknown message types deserialize as `Message::Unknown` instead of erroring
- [x] All existing tests pass (`cargo test --features testing` — 240 tests)