### PR TITLE
Fix: Reset buffer_size after each JSON message to prevent stream death

### DIFF
--- a/src/internal/transport/subprocess.rs
+++ b/src/internal/transport/subprocess.rs
@@ -773,6 +773,7 @@ impl Transport for SubprocessTransport {
 
                             match serde_json::from_str::<serde_json::Value>(trimmed) {
                                 Ok(json) => {
+                                    buffer_size = 0;  // Reset after successful parse
                                     yield Ok(json);
                                 }
                                 Err(e) => {


### PR DESCRIPTION
The buffer_size counter in read_messages() accumulated bytes across ALL messages read from stdout, never resetting after successful parses. With the default max_buffer_size of 10MB, any long-running session that processed enough stdout data would eventually trigger the limit, causing the transport stream to yield an error and break. This led to silent hangs where the Claude Code subprocess continued running but no events reached consumers.

The fix resets buffer_size to 0 after each successfully parsed JSON message, matching [the Python SDK's behavior](https://github.com/anthropics/claude-agent-sdk-python/blob/a3c3a01022cc680a1a3c9aa497671525f340fdb0/src/claude_agent_sdk/_internal/transport/subprocess_cli.py#L567), which clears `json_buffer` after successful json parsing.
