### PR TITLE
Fix: Prevent silent event stream hang via in-band sentinel messages

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -560,6 +560,25 @@ impl ClaudeClient {
 
             // No mutex needed - flume receiver is lock-free
             while let Ok(json) = rx.recv_async().await {
+                // Check for sentinel messages before parsing
+                // These are sent by the background task when it exits
+                if let Some(msg_type) = json.get("type").and_then(|v| v.as_str()) {
+                    if msg_type == "end" {
+                        // End sentinel - stream is done
+                        break;
+                    }
+                    if msg_type == "error" {
+                        // Error sentinel - yield error and end stream
+                        let error_msg = json.get("error")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("Unknown error");
+                        yield Err(ClaudeError::Transport(format!(
+                            "Background reader task failed: {}", error_msg
+                        )));
+                        break;
+                    }
+                }
+
                 match MessageParser::parse(json) {
                     Ok(msg) => yield Ok(msg),
                     Err(e) => yield Err(e),

--- a/src/internal/query_full.rs
+++ b/src/internal/query_full.rs
@@ -65,7 +65,8 @@ pub struct QueryFull {
     request_counter: Arc<AtomicU64>,
     /// Pending control request responses - concurrent access via DashMap
     pending_responses: Arc<DashMap<String, oneshot::Sender<serde_json::Value>>>,
-    message_tx: flume::Sender<serde_json::Value>,
+    /// Message sender - Option so start() can take ownership via .take()
+    message_tx: Option<flume::Sender<serde_json::Value>>,
     /// Message receiver - cloneable without mutex thanks to flume
     pub(crate) message_rx: flume::Receiver<serde_json::Value>,
     /// Initialization result - set once during initialize(), read many times
@@ -84,7 +85,7 @@ impl QueryFull {
             next_callback_id: Arc::new(AtomicU64::new(0)),
             request_counter: Arc::new(AtomicU64::new(0)),
             pending_responses: Arc::new(DashMap::new()),
-            message_tx,
+            message_tx: Some(message_tx),
             message_rx,
             initialization_result: OnceLock::new(),
         }
@@ -102,7 +103,7 @@ impl QueryFull {
             next_callback_id: Arc::new(AtomicU64::new(0)),
             request_counter: Arc::new(AtomicU64::new(0)),
             pending_responses: Arc::new(DashMap::new()),
-            message_tx,
+            message_tx: Some(message_tx),
             message_rx,
             initialization_result: OnceLock::new(),
         }
@@ -175,13 +176,17 @@ impl QueryFull {
     ///
     /// Returns a receiver that signals when the background task completes.
     /// The caller should store this and await it during disconnect.
-    pub async fn start(&self) -> Result<oneshot::Receiver<()>> {
+    pub async fn start(&mut self) -> Result<oneshot::Receiver<()>> {
         let transport = Arc::clone(&self.transport);
         let transport_for_hooks = Arc::clone(&self.transport);
         let hook_callbacks = Arc::clone(&self.hook_callbacks);
         let sdk_mcp_servers = Arc::clone(&self.sdk_mcp_servers);
         let pending_responses = Arc::clone(&self.pending_responses);
-        let message_tx = self.message_tx.clone();
+        // Take ownership of message_tx
+        let message_tx = self
+            .message_tx
+            .take()
+            .expect("start() must only be called once");
 
         // Create a channel to signal when background task is ready
         let (ready_tx, ready_rx) = oneshot::channel();
@@ -195,6 +200,8 @@ impl QueryFull {
 
             // Signal that we're ready to receive messages
             let _ = ready_tx.send(());
+
+            let mut stream_error: Option<String> = None;
 
             while let Some(result) = stream.next().await {
                 match result {
@@ -244,9 +251,28 @@ impl QueryFull {
                             }
                         }
                     }
-                    Err(_) => break,
+                    Err(e) => {
+                        // Store error for sentinel message
+                        stream_error = Some(e.to_string());
+                        break;
+                    }
                 }
             }
+
+            // Signal pending control requests on error
+            if stream_error.is_some() {
+                // Unblock all pending control requests by removing them
+                // (the oneshot channels will error when dropped)
+                pending_responses.clear();
+            }
+
+            // Send error sentinel if there was an error
+            if let Some(ref error) = stream_error {
+                let _ = message_tx.send(json!({"type": "error", "error": error}));
+            }
+
+            // Always send end sentinel
+            let _ = message_tx.send(json!({"type": "end"}));
 
             // Signal that background task has completed
             let _ = shutdown_tx.send(());


### PR DESCRIPTION
Two issues caused silent failures in the event stream:

1. Dangling sender causes infinite hang: The message_tx sender was stored in the QueryFull struct and cloned for the background task. When the bg task died, its clone was dropped, but the original survived. Flume's
recv_async() only returns Err when all senders are dropped, so consumers blocked forever.
2. Transport errors silently discarded: When the background reader encountered a JSON decode failure, it simply broke from the loop without propagating the error. Consumers received no indication of failure.

Together, these meant a transport error would silently kill the event stream while consumers hung forever.

This PR resolves these issues by aligning with the Python SDK's sentinel message pattern.

Background task sends sentinel messages before exiting ([corresponding Python SDK lines](https://github.com/anthropics/claude-agent-sdk-python/blob/d6f035259f2d7ac0ec284fc1aa1211ac2cd7ca8b/src/claude_agent_sdk/_internal/query.py#L220-L234)):
- On error, send `{"type": "error", "error": "..."}`
- Always send `{"type": "end"}`
- Clear pending control requests on error so they fail fast

`receive_messages()` checks for sentinels pre-parse ([corresponding Python SDK lines](https://github.com/anthropics/claude-agent-sdk-python/blob/d6f035259f2d7ac0ec284fc1aa1211ac2cd7ca8b/src/claude_agent_sdk/_internal/query.py#L651-L655)):
- `"type": "end"` → end stream cleanly
- `"type": "error"` → yield error and end stream

Remove dangling sender (rust specific):
- Changed `message_tx` to `Option<Sender>`
- `start(&mut self)` takes ownership via `.take()`
- No sender survives in the struct after `start()`
