### PR TITLE
Make error types Clone + Serialize + Deserialize

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,10 +1,11 @@
 //! Error types for the Claude Agent SDK
 
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use thiserror::Error;
 
 /// Main error type for the Claude Agent SDK
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, Error, Serialize, Deserialize)]
 pub enum ClaudeError {
     /// CLI connection error
     #[error("CLI connection error: {0}")]
@@ -42,17 +43,13 @@ pub enum ClaudeError {
     #[error("Image validation error: {0}")]
     ImageValidation(#[from] ImageValidationError),
 
-    /// IO error
-    #[error("IO error: {0}")]
-    Io(#[from] std::io::Error),
-
-    /// Other errors
-    #[error(transparent)]
-    Other(#[from] anyhow::Error),
+    /// Other errors (stores error message as string for serializability)
+    #[error("{0}")]
+    Other(String),
 }
 
 /// Error when Claude Code CLI cannot be found
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, Error, Serialize, Deserialize)]
 #[error("CLI not found: {message}")]
 pub struct CliNotFoundError {
     /// Error message
@@ -72,7 +69,7 @@ impl CliNotFoundError {
 }
 
 /// Error when connecting to Claude Code CLI
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, Error, Serialize, Deserialize)]
 #[error("Connection error: {message}")]
 pub struct ConnectionError {
     /// Error message
@@ -89,7 +86,7 @@ impl ConnectionError {
 }
 
 /// Error when the CLI process fails
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, Error, Serialize, Deserialize)]
 #[error("Process error (exit code {exit_code:?}): {message}")]
 pub struct ProcessError {
     /// Error message
@@ -112,7 +109,7 @@ impl ProcessError {
 }
 
 /// Error when JSON decoding fails
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, Error, Serialize, Deserialize)]
 #[error("JSON decode error: {message}")]
 pub struct JsonDecodeError {
     /// Error message
@@ -132,7 +129,7 @@ impl JsonDecodeError {
 }
 
 /// Error when message parsing fails
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, Error, Serialize, Deserialize)]
 #[error("Message parse error: {message}")]
 pub struct MessageParseError {
     /// Error message
@@ -152,7 +149,7 @@ impl MessageParseError {
 }
 
 /// Image validation error
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, Error, Serialize, Deserialize)]
 #[error("Image validation error: {message}")]
 pub struct ImageValidationError {
     /// Error message

--- a/src/types/efficiency.rs
+++ b/src/types/efficiency.rs
@@ -6,6 +6,7 @@
 //! - Providing efficiency feedback with specific warnings when execution stops
 
 use futures::future::BoxFuture;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -159,7 +160,7 @@ impl ExecutionMetrics {
 }
 
 /// Summary of execution metrics
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MetricsSummary {
     pub total_tool_calls: u32,
     pub total_edits: u32,

--- a/src/types/hooks.rs
+++ b/src/types/hooks.rs
@@ -172,7 +172,7 @@ pub struct PreCompactHookInput {
 }
 
 /// Hook context passed to callbacks
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct HookContext {
     /// Abort signal (future feature)
     pub signal: Option<()>,

--- a/src/types/mcp.rs
+++ b/src/types/mcp.rs
@@ -263,7 +263,11 @@ macro_rules! tool {
                 use futures::FutureExt;
                 let f = &self.0;
                 let fut = f(args);
-                async move { fut.await.map_err(|e| e.into()) }.boxed()
+                async move {
+                    fut.await
+                        .map_err(|e| $crate::errors::ClaudeError::Other(e.to_string()))
+                }
+                .boxed()
             }
         }
 

--- a/src/types/permissions.rs
+++ b/src/types/permissions.rs
@@ -60,7 +60,7 @@ impl Default for PermissionResultDeny {
 }
 
 /// Permission update to apply
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PermissionUpdate {
     /// Type of update
     #[serde(rename = "type")]
@@ -101,7 +101,7 @@ pub enum PermissionUpdateType {
 }
 
 /// Permission rule value
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PermissionRuleValue {
     /// Tool name for this rule
     #[serde(rename = "toolName")]


### PR DESCRIPTION
All public error types now derive Clone, Serialize, and Deserialize, making them easier to use in client applications that need to store, transmit, or clone errors.

Changes:
- Added Clone, Serialize, Deserialize to ClaudeError and all nested error types
- Removed unused Io(std::io::Error) variant from ClaudeError
- Changed Other(anyhow::Error) to Other(String) to enable serialization
- Updated tool! macro to convert anyhow::Error to string
- Added Serialize, Deserialize to HookContext and MetricsSummary

Breaking changes:
- ClaudeError::Io variant removed (was unused)
- ClaudeError::Other now holds String instead of anyhow::Error
