### PR TITLE
[fix] Do not crash SDK when claude prints to stderr

### DIFF
--- a/src/internal/transport/subprocess.rs
+++ b/src/internal/transport/subprocess.rs
@@ -673,7 +673,7 @@ impl Transport for SubprocessTransport {
         cmd.args(&args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
+            .stderr(if self.options.stderr_callback.is_some() { Stdio::piped() } else { Stdio::null() })
             .envs(&env);
 
         if let Some(ref cwd) = self.cwd {


### PR DESCRIPTION
Summary:
The SDK transport spawns the `claude` process and always pipes stdin, stdout and stderr. While stdin and stdout are stored in the transport struct to power the streaming functionality, stderr is only ever read from if the user specified a `stderr_callback` to call on each line.

This creates a subtle serious bug: if the claude process tries to write to stderr and user has not specified the `stderr_callback`, the process will crash before reading all (or potentially any) lines of stdout.

More specifically, this is what happens:
1. the SDK spawns the process and takes stdin, stdout and stderr
2. there is no `stderr_callback`, thus no thread is spawn to read from stderr
3. SubprocessTransport::connect returns and the taken stderr handle is dropped, this closes the associated file descriptor
4. the `claude` process tries to write to stderr, but it's closed so it receives a SIGPIPE and panics
5. by then, SubprocessTransport::read_messages has spawned a thread that is waiting to read from stdout (but most likely has received no messages yet); since the process exited this thread receives EOF immediately since the stdout pipe gets closed
6. as a result, the caller of read_messages exits without receiving any messages

This diff fixes the issue by only piping stderr when the caller actually intends to read from it (i.e., when `stderr_callback` is defined).

With this change, when the callback is not defined, stderr is None and all stderr output produced by the `claude` process will be correctly ignored.

Test Plan:

Replace `claude` on PATH with a wrapper that prints some messages to stderr and then execs `claude`.

Create a test project:
```
cat main.rs
use futures::StreamExt;

async fn main() {
    println!("Creating stream...");
    let mut stream = claude_agent_sdk_rs::query_stream("How much is 1+1?", None)
        .await
        .unwrap();

    println!("Querying claude agent sdk...");
    while let Some(result) = stream.next().await {
        let message = result.unwrap();
        println!("{:?}", message);
    }
    println!("Done.");
}
```

```
cargo run
   Compiling claude-agent-sdk-rs-playground v0.1.0 (/home/andryak/git-repos/claude-agent-sdk-rs-playground)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.96s
     Running `/home/andryak/git-repos/claude-agent-sdk-rs-playground/target/debug/claude-agent-sdk-rs-playground`
Creating stream...
Querying claude agent sdk...
Done.
```

Run the fixed version of the SDK, messages are correctly received:
```
cargo run
   Compiling claude-agent-sdk-rs v0.6.4 (/home/andryak/git-repos/claude-agent-sdk-rs)
   Compiling claude-agent-sdk-rs-playground v0.1.0 (/home/andryak/git-repos/claude-agent-sdk-rs-playground)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.88s
     Running `/home/andryak/git-repos/claude-agent-sdk-rs-playground/target/debug/claude-agent-sdk-rs-playground`
Creating stream...
Querying claude agent sdk...
System(SystemMessage { subtype: "hook_started", cwd: None, session_id: Some("6718343d-1a6a-441b-b6a9-9d469a72874a"), tools: None, mcp_servers: None, model: None, permission_mode: None, uuid: Some("112b6aeb-51ba-498f-ae70-0b04cb627674"), data: Object {"hook_event": String("SessionStart"), "hook_id": String("346f4448-b083-425a-9c14-bcd07a23e811"), "hook_name": String("SessionStart:startup")} })
...
Assistant(AssistantMessage { message: AssistantMessageInner { content: [Text(TextBlock { text: "2" })], model: Some("claude-opus-4-6"), id: Some("msg_vrtx_016197LUw5BEUUfMTidWFrkZ"), stop_reason: None, usage: Some(Object {"cache_creation": Object {"ephemeral_1h_input_tokens": Number(0), "ephemeral_5m_input_tokens": Number(28777)}, "cache_creation_input_tokens": Number(28777), "cache_read_input_tokens": Number(0), "input_tokens": Number(2), "output_tokens": Number(1)}), error: None }, parent_tool_use_id: None, session_id: Some("6718343d-1a6a-441b-b6a9-9d469a72874a"), uuid: Some("4cc0efb8-8dfd-45e5-b284-046932cd378b") })
...
Done.
```