### PR TITLE
feat: Add uid/gid options for spawned Claude CLI process (Unix)

### DIFF
--- a/src/internal/transport/subprocess.rs
+++ b/src/internal/transport/subprocess.rs
@@ -680,6 +680,18 @@ impl Transport for SubprocessTransport {
             cmd.current_dir(cwd);
         }
 
+        // Set uid/gid of the spawned process (Unix only).
+        // `tokio::process::Command` provides inherent `uid`/`gid` methods on Unix.
+        #[cfg(unix)]
+        {
+            if let Some(uid) = self.options.uid {
+                cmd.uid(uid);
+            }
+            if let Some(gid) = self.options.gid {
+                cmd.gid(gid);
+            }
+        }
+
         // Spawn process
         let mut child = cmd.spawn().map_err(|e| {
             ClaudeError::Process(ProcessError::new(

--- a/src/types/config.rs
+++ b/src/types/config.rs
@@ -77,6 +77,20 @@ pub struct ClaudeAgentOptions {
     /// Environment variables
     #[builder(default)]
     pub env: HashMap<String, String>,
+    /// User ID (uid) to run the spawned Claude CLI process as (Unix only).
+    ///
+    /// When set, the SDK calls `Command::uid()` before spawning. Requires the
+    /// host process to have sufficient privileges (typically root).
+    #[cfg(unix)]
+    #[builder(default, setter(strip_option))]
+    pub uid: Option<u32>,
+    /// Group ID (gid) to run the spawned Claude CLI process as (Unix only).
+    ///
+    /// When set, the SDK calls `Command::gid()` before spawning. Requires the
+    /// host process to have sufficient privileges (typically root).
+    #[cfg(unix)]
+    #[builder(default, setter(strip_option))]
+    pub gid: Option<u32>,
     /// Extra CLI arguments
     #[builder(default)]
     pub extra_args: HashMap<String, Option<String>>,
@@ -590,6 +604,22 @@ mod tests {
             }
             _ => panic!("Expected Some(Tools::List)"),
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_uid_gid_in_options_builder() {
+        let options = ClaudeAgentOptions::builder().uid(1000).gid(1000).build();
+        assert_eq!(options.uid, Some(1000));
+        assert_eq!(options.gid, Some(1000));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_uid_gid_default_none() {
+        let options = ClaudeAgentOptions::default();
+        assert_eq!(options.uid, None);
+        assert_eq!(options.gid, None);
     }
 
     #[test]


### PR DESCRIPTION
Hello,
Thank you for the project !
A small PR to add 2 options fields to allow changing the user/group of the spawned claude process.

Add optional uid and gid fields to ClaudeAgentOptions, gated with #[cfg(unix)], allowing callers to control the user/group identity of the Claude CLI subprocess. Applied via tokio::process::Command's inherent uid/gid methods just before spawn in SubprocessTransport::connect().